### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bitnami/sre


### PR DESCRIPTION
CODEOWNERS are an automation-friendly way to tell who are the go-to people for doing code reviews in a given repo